### PR TITLE
feat: Added latest Polygon/USD price, tested historic data on this contract

### DIFF
--- a/components/price/Feed.vue
+++ b/components/price/Feed.vue
@@ -1,5 +1,10 @@
 <script setup lang="ts">
 const ethUsd = await useEthPrice()
+const polygonEthUsd = await usePolygonPrice()
+
+// Used as a test to check
+// const historicPolygon = await historicPolygonPrice()
+// console.log(historicPolygon)
 </script>
 
 <template>
@@ -23,7 +28,7 @@ const ethUsd = await useEthPrice()
       </div>
       <div flex items-center text-sm>
         <div px-2 py-2px bg-element font-bold rounded-md>
-          ??
+          ${{ polygonEthUsd }}
         </div>
       </div>
     </div>

--- a/composables/priceFeeds.ts
+++ b/composables/priceFeeds.ts
@@ -1,61 +1,80 @@
 import { ethers } from 'ethers'
 
-export const useEthPrice = async () => {
-  const provider = await useRpcProvider()
-  const aggregatorV3InterfaceABI = [
-    {
-      inputs: [],
-      name: 'decimals',
-      outputs: [{ internalType: 'uint8', name: '', type: 'uint8' }],
-      stateMutability: 'view',
-      type: 'function',
-    },
-    {
-      inputs: [],
-      name: 'description',
-      outputs: [{ internalType: 'string', name: '', type: 'string' }],
-      stateMutability: 'view',
-      type: 'function',
-    },
-    {
-      inputs: [{ internalType: 'uint80', name: '_roundId', type: 'uint80' }],
-      name: 'getRoundData',
-      outputs: [
-        { internalType: 'uint80', name: 'roundId', type: 'uint80' },
-        { internalType: 'int256', name: 'answer', type: 'int256' },
-        { internalType: 'uint256', name: 'startedAt', type: 'uint256' },
-        { internalType: 'uint256', name: 'updatedAt', type: 'uint256' },
-        { internalType: 'uint80', name: 'answeredInRound', type: 'uint80' },
-      ],
-      stateMutability: 'view',
-      type: 'function',
-    },
-    {
-      inputs: [],
-      name: 'latestRoundData',
-      outputs: [
-        { internalType: 'uint80', name: 'roundId', type: 'uint80' },
-        { internalType: 'int256', name: 'answer', type: 'int256' },
-        { internalType: 'uint256', name: 'startedAt', type: 'uint256' },
-        { internalType: 'uint256', name: 'updatedAt', type: 'uint256' },
-        { internalType: 'uint80', name: 'answeredInRound', type: 'uint80' },
-      ],
-      stateMutability: 'view',
-      type: 'function',
-    },
-    {
-      inputs: [],
-      name: 'version',
-      outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
-      stateMutability: 'view',
-      type: 'function',
-    },
-  ]
+// Mainnet ETH/USD Chainlink contract
+const ethUsdAddress = '0x5f4ec3df9cbd43714fe2740f5e3616155c5b8419'
+// Polygon ETH/USD Chainlink contract
+const polygonUsdAddress = '0x7bac85a8a13a4bcd8abb3eb7d6b4d632c5a57676'
 
-  // Mainnet ETH/USD Chainlink contract
-  const addr = '0x5f4ec3df9cbd43714fe2740f5e3616155c5b8419'
-  const priceFeed = new ethers.Contract(addr, aggregatorV3InterfaceABI, provider)
+const provider = await useRpcProvider()
+const aggregatorV3InterfaceABI = [
+  {
+    inputs: [],
+    name: 'decimals',
+    outputs: [{ internalType: 'uint8', name: '', type: 'uint8' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'description',
+    outputs: [{ internalType: 'string', name: '', type: 'string' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [{ internalType: 'uint80', name: '_roundId', type: 'uint80' }],
+    name: 'getRoundData',
+    outputs: [
+      { internalType: 'uint80', name: 'roundId', type: 'uint80' },
+      { internalType: 'int256', name: 'answer', type: 'int256' },
+      { internalType: 'uint256', name: 'startedAt', type: 'uint256' },
+      { internalType: 'uint256', name: 'updatedAt', type: 'uint256' },
+      { internalType: 'uint80', name: 'answeredInRound', type: 'uint80' },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'latestRoundData',
+    outputs: [
+      { internalType: 'uint80', name: 'roundId', type: 'uint80' },
+      { internalType: 'int256', name: 'answer', type: 'int256' },
+      { internalType: 'uint256', name: 'startedAt', type: 'uint256' },
+      { internalType: 'uint256', name: 'updatedAt', type: 'uint256' },
+      { internalType: 'uint80', name: 'answeredInRound', type: 'uint80' },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'version',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+
+    type: 'function',
+  },
+]
+
+export const useEthPrice = async () => {
+  const priceFeed = new ethers.Contract(ethUsdAddress, aggregatorV3InterfaceABI, provider)
   const roundData = await priceFeed.latestRoundData()
   const decimals = await priceFeed.decimals()
   return Number((roundData.answer.toString() / 10 ** decimals).toFixed(2))
+}
+
+export const usePolygonPrice = async () => {
+  const priceFeed = new ethers.Contract(polygonUsdAddress, aggregatorV3InterfaceABI, provider)
+  const roundData = await priceFeed.latestRoundData()
+  const decimals = await priceFeed.decimals()
+  return Number((roundData.answer.toString()) / 10 ** decimals).toFixed(2)
+}
+
+export const historicPolygonPrice = async () => {
+  const priceFeed = new ethers.Contract(polygonUsdAddress, aggregatorV3InterfaceABI, provider)
+  // We can loop through the roundId parameter to get the token price at each round, hardcoded as example
+  const roundData = await priceFeed.getRoundData(55340232221128668506n)
+  const decimals = await priceFeed.decimals()
+  return Number((roundData.answer.toString()) / 10 ** decimals).toFixed(2)
 }


### PR DESCRIPTION
Started on the Polygon/USD contract to populate it with the latest round data, this works and renders on the app.

I've made the `provider` and `aggregatorV3InterfaceABI` variables global to allow for reuse, as well as declaring the contract addresses globally.

Found how to view historic data from this contract and used the Polygonscan link ('https://etherscan.io/address/0x7bAC85A8a13A4BcD8abb3eB7d6b4d632c5a57676#readContract') to verify the data. The task now would be to have this as a live display for users previous transactions?

