### PR TITLE
Added wallet, gas and block# for mob-header

### DIFF
--- a/components/mobile/Header.vue
+++ b/components/mobile/Header.vue
@@ -5,7 +5,17 @@ const props = defineProps<{
 </script>
 
 <template>
-  <div>
-    Header
+  <div w-full>
+    <div col-span-3 flex h-full items-center>
+      <div w-full pl-2>
+        <GasPrice />
+      </div>
+      <div w-full pl-1 pr-1>
+        <Wallet />
+      </div>
+      <div w-full pr-2>
+        <NetworkInfo />
+      </div>
+    </div>
   </div>
 </template>


### PR DESCRIPTION
This is super basic, primarily so we can see the wallet when using a mobile browser such as Brave.

Also added the `NetworkInfo` and `GasPrice` just to fill the space ...