### PR TITLE
feat: Added InjectedWallet test

### DIFF
--- a/components/Connect.vue
+++ b/components/Connect.vue
@@ -3,6 +3,7 @@ import { connect } from '@wagmi/core'
 import { arbitrum, mainnet, optimism, polygon } from '@wagmi/core/chains'
 import { MetaMaskConnector } from '@wagmi/core/connectors/metaMask'
 import { WalletConnectConnector } from '@wagmi/core/connectors/walletConnect'
+import { InjectedConnector } from '@wagmi/core'
 
 const chains = [mainnet, optimism, arbitrum, polygon]
 
@@ -12,6 +13,13 @@ const walletconnect = new WalletConnectConnector({
   options: {
     qrcode: true,
   },
+})
+const injectedWallet = new InjectedConnector({
+  chains,
+  options: {
+    name: "Injected",
+    shimDisconnect: true
+  }
 })
 </script>
 
@@ -42,6 +50,16 @@ const walletconnect = new WalletConnectConnector({
         <Icon name="walletconnect" size="3.5rem" />
         <div text-xl>
           WalletConnect
+        </div>
+      </div>
+      <div
+        h-28 mt-2 flex-col-center rounded-2xl bg-element hover:bg-element-active
+        cursor-pointer
+        @click="connect({ connector: injectedWallet })"
+      >
+        <Icon name="walletconnect" size="3.5rem" />
+        <div text-xl>
+          Injected Connector
         </div>
       </div>
     </div>


### PR DESCRIPTION
This is a bit rough because it's still using the `walletconnect` icon. Do we have a way we can push changes to test them live without being on the production version?

This would be helpful for this PR as I would just like to test the `Injected Wallet` on the Brave mobile browser. However, there are no breaking changes so it is still safe for production.