### PR TITLE
Started dropdowns, network & wallet

### DIFF
--- a/components/Connect.vue
+++ b/components/Connect.vue
@@ -1,25 +1,5 @@
 <script setup lang="ts">
-import { InjectedConnector, connect } from '@wagmi/core'
-import { arbitrum, mainnet, optimism, polygon } from '@wagmi/core/chains'
-import { MetaMaskConnector } from '@wagmi/core/connectors/metaMask'
-import { WalletConnectConnector } from '@wagmi/core/connectors/walletConnect'
-
-const chains = [mainnet, optimism, arbitrum, polygon]
-
-const metamask = new MetaMaskConnector({ chains })
-const walletconnect = new WalletConnectConnector({
-  chains,
-  options: {
-    qrcode: true,
-  },
-})
-const injectedWallet = new InjectedConnector({
-  chains,
-  options: {
-    name: 'Injected',
-    shimDisconnect: true,
-  },
-})
+import { connect } from '@wagmi/core'
 </script>
 
 <template>

--- a/components/account/Menu.vue
+++ b/components/account/Menu.vue
@@ -4,10 +4,6 @@ import { disconnect } from '@wagmi/core'
 const config = useRuntimeConfig()
 const wallet = useWalletStore()
 const items = {
-  disconnect: {
-    icon: { name: 'disconnect' },
-    label: 'Disconnect',
-  },
   web3VueNuxtProjects: {
     icon: { name: 'vue' },
     label: 'Vue web3 projects',
@@ -51,7 +47,6 @@ const items = {
     :toggle-icon="{ name: 'menu', size: '1.4rem' }"
     toggle-class="btn-transparent"
   >
-    <MenuItem v-if="wallet.connected" :item="items.disconnect" @click.prevent="disconnect()" />
     <MenuItem v-slot="{ active }">
       <ThemeToggle :class="[active ? 'bg-element' : undefined]" @click.prevent />
     </MenuItem>

--- a/components/mobile/Header.vue
+++ b/components/mobile/Header.vue
@@ -2,7 +2,7 @@
   <div h-16 flex items-center px-3 border-b-1 border-highlight box-border>
     <div flex-center w-10 h-10 text-2xl>
       <div>
-        🦧
+        <Network />
       </div>
     </div>
     <div flex-1 flex justify-center>

--- a/components/network/Network.vue
+++ b/components/network/Network.vue
@@ -1,11 +1,28 @@
 <script setup lang="ts">
 // const defaultProvider = await useDefaultProvider()
+const items = {
+  matic: {
+    icon: { name: 'polygon' },
+    label: 'Polygon',
+  },
+  optimism: {
+    icon: { name: 'optimism' },
+    label: 'Optimism',
+  },
+  xDai: {
+    icon: { name: 'xdai' },
+    label: 'xDai',
+  },
+}
 </script>
 
 <template>
-  <div btn-transparent px-4>
-    <Icon name="dropdown" size="0.8rem" text-dim />
-    <Icon name="ethereum" size="1.2rem" px-1 />
-    <div>Ethereum</div>
-  </div>
+  <Menu
+    :toggle-icon="{ name: 'ethereum', size: '1.4rem' }"
+    toggle-class="btn-transparent"
+  >
+    <MenuItem :item="items.matic" />
+    <MenuItem :item="items.optimism" />
+    <MenuItem :item="items.xDai" />
+  </Menu>
 </template>

--- a/components/wallet/Wallet.vue
+++ b/components/wallet/Wallet.vue
@@ -1,13 +1,25 @@
 <script setup lang="ts">
 const wallet = useWalletStore()
+const items = {
+  disconnect: {
+    icon: { name: 'disconnect' },
+    label: 'Disconnect',
+  },
+}
 </script>
 
 <template>
-  <div v-if="wallet.address" btn-transparent px-2 md:px-4>
+  <!-- <div v-if="wallet.address" btn-transparent px-2 md:px-4>
     <Icon name="dropdown" size="0.8rem" text-dim />
     <Icon name="wallet" size="1.4rem" mx-2 />
     <div self-center class="text-address">
       {{ displayAddress(wallet.address) }}
     </div>
-  </div>
+  </div> -->
+  <Menu
+    toggle-class="btn-transparent"
+    :toggle-icon="{ name: 'wallet', size: '1.4rem' }"
+  >
+    <MenuItem :item="items.disconnect" />
+  </Menu>
 </template>

--- a/components/wallet/Wallet.vue
+++ b/components/wallet/Wallet.vue
@@ -1,6 +1,11 @@
 <script setup lang="ts">
+import { connect, disconnect } from '@wagmi/core'
 const wallet = useWalletStore()
 const items = {
+  connect: {
+    icon: { name: 'wallet' },
+    label: 'Connect',
+  },
   disconnect: {
     icon: { name: 'disconnect' },
     label: 'Disconnect',
@@ -20,6 +25,7 @@ const items = {
     toggle-class="btn-transparent"
     :toggle-icon="{ name: 'wallet', size: '1.4rem' }"
   >
-    <MenuItem :item="items.disconnect" />
+    <MenuItem v-if="!wallet.connected" :item="items.connect" @click.prevent="connect({ connector: metamask })" />
+    <MenuItem v-if="wallet.connected" :item="items.disconnect" @click.prevent="disconnect()" />
   </Menu>
 </template>

--- a/composables/walletConnect.ts
+++ b/composables/walletConnect.ts
@@ -1,0 +1,21 @@
+import { InjectedConnector } from '@wagmi/core'
+import { MetaMaskConnector } from '@wagmi/core/connectors/metaMask'
+import { arbitrum, mainnet, optimism, polygon } from '@wagmi/core/chains'
+import { WalletConnectConnector } from '@wagmi/core/connectors/walletConnect'
+
+export const chains = [mainnet, optimism, arbitrum, polygon]
+
+export const metamask = new MetaMaskConnector({ chains })
+export const walletconnect = new WalletConnectConnector({
+  chains,
+  options: {
+    qrcode: true,
+  },
+})
+export const injectedWallet = new InjectedConnector({
+  chains,
+  options: {
+    name: 'Injected',
+    shimDisconnect: true,
+  },
+})


### PR DESCRIPTION
Firstly, Merry Christmas!

After looking at a Zapper/Zerion I figured maybe theres going to be more than one connect/disconnect hence the `walletConnect.ts` composable? I also moved the `disconnect()` to the wallet dropdown as this seems more fitting?

I started playing around with the dropdown buttons, the headless stuff is new to me so I've ran in to a few issues I need some help with (if we do decide to merge this PR).

I can see on the `components/menu/Menu.vue` that the transition can be adjusted, and I managed to this successfully for the `Network.vue` dropdown (when testing), as the dropdown would need to be on the right. However, my problem is I don't know the best way to have multiple different `<transition>` states given the buttons are headless?

The next issue I had was trying to get the `wallet.address` to display as part of the `<HeadlessMenuButton>`. I tried playing around with the types and even changed the following to test: 

`toggleLabel?: string` became `toggleLabel?: string | Wallet`, but no joy?

I'm also conscious that the network dropdown is pointless if it does not update the state of the rest of the data, so would Pinia help solve this issue?